### PR TITLE
[backend] fix: use ENV.fetch instead of ENV

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,15 +1,14 @@
 default: &default
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  splitwise_consumer_key: <%= ENV["SPLITWISE_CONSUMER_KEY"] %>
-  splitwise_consumer_secret: <%= ENV["SPLITWISE_CONSUMER_SECRET"] %>
-  splitwise_token_url: <%= ENV["SPLITWISE_TOKEN_URL"] %>
-  splitwise_access_token_url: <%= ENV["SPLITWISE_ACCESS_TOKEN_URL"] %>
-  splitwise_authorize_url: <%= ENV["SPLITWISE_AUTHORIZE_URL"] %>
-  splitwise_callback_url: <%= ENV["SPLITWISE_CALLBACK_URL"] %>
-  splitwise_base_site: <%= ENV["SPLITWISE_BASE_SITE"] %>
-  buda_payment_simulation: <%= ENV["INVOICE_PAYMENT_SIMULATION"] %>
-
-  firebase_credentials:  <%= ENV["FIREBASE_CREDENTIALS"] %>
+  secret_key_base: <%= ENV.fetch("SECRET_KEY_BASE") %>
+  splitwise_consumer_key: <%= ENV.fetch("SPLITWISE_CONSUMER_KEY") %>
+  splitwise_consumer_secret: <%= ENV.fetch("SPLITWISE_CONSUMER_SECRET") %>
+  splitwise_token_url: <%= ENV.fetch("SPLITWISE_TOKEN_URL") %>
+  splitwise_access_token_url: <%= ENV.fetch("SPLITWISE_ACCESS_TOKEN_URL") %>
+  splitwise_authorize_url: <%= ENV.fetch("SPLITWISE_AUTHORIZE_URL") %>
+  splitwise_callback_url: <%= ENV.fetch("SPLITWISE_CALLBACK_URL") %>
+  splitwise_base_site: <%= ENV.fetch("SPLITWISE_BASE_SITE") %>
+  buda_payment_simulation: <%= ENV.fetch("INVOICE_PAYMENT_SIMULATION") %>
+  firebase_credentials: <%= ENV.fetch("FIREBASE_CREDENTIALS") %>
 
 development:
   <<: *default


### PR DESCRIPTION
Al usar ENV retornará nil en caso de que no este seteada, lo que puede generar errores inesperados. Mejor usar fetch para que lance un error y sabemos que el problema es una variable de entorno que nos falta.