### PR TITLE
[Web] Firebase notification fix

### DIFF
--- a/app/javascript/components/NavBarNotifications.vue
+++ b/app/javascript/components/NavBarNotifications.vue
@@ -15,35 +15,28 @@
       </svg>
       <span>{{ unSeenNotifications.length }}</span>
     </button>
-    <div
-      v-show="!hidden"
-      class="absolute bg-gray-400 mt-4 ml-2"
-    >
+    <div v-show="!hidden" class="absolute bg-gray-400 mt-4 ml-2">
       <div
         class="absolute z-0 w-4 h-4 origin-center transform rotate-45 translate-x-5 -translate-y-2 bg-gray-400 border-t border-l border-gray-200 rounded-sm pointer-events-none"
       />
-      <div
-        v-show="!hasNotifications"
-        class="m-2"
-      >
+      <div v-show="!hasNotifications" class="m-2">
         No tienes notificaciones sin leer
       </div>
-      <div
-        v-show="hasNotifications"
-        class="pr-2 h-64 overflow-y-auto"
-      >
+      <div v-show="hasNotifications" class="pr-2 h-64 overflow-y-auto">
         <ul
           v-for="notification in unSeenNotifications"
           :key="notification['.key']"
         >
           <li class="p-3 border-black border-solid hover:bg-gray-500 z-40">
-            <div
-              v-show="notification.type === 'payment'"
-              class="flex flex-row"
-            >
+            <div v-show="notification.type === 'payment'" class="flex flex-row">
               <RightArrow color="seaGreen" />
-              <p class="pl-2 font-thin">
-                Recibido BTC {{ notification.data.amount }}
+              <p v-if="notification.data.sender" class="pl-2 font-thin">
+                {{
+                  `${notification.data.sender} te ha enviado ${notification.data.amount} BTC`
+                }}
+              </p>
+              <p v-else class="pl-2 font-thin">
+                {{ `Has recibido ${notification.data.amount} BTC` }}
               </p>
               <button @click="markAsSeen(notification['.key'])">
                 <Cross class="ml-2 cursor-pointer" />

--- a/app/javascript/store/modules/notification/index.js
+++ b/app/javascript/store/modules/notification/index.js
@@ -25,7 +25,8 @@ const actions = {
   unbindNotifications: firebaseAction(({ unbindFirebaseRef }) => {
     unbindFirebaseRef('notifications');
   }),
-  markAsSeen: firebaseAction(notificationToken =>
+  // eslint-disable-next-line no-empty-pattern
+  markAsSeen: firebaseAction(({}, notificationToken) =>
     markAsSeenApi(notificationToken)
   ),
 };


### PR DESCRIPTION
Agrega bug que hacia que no se marcaran como leidas las notificaciones.
El problema fue que [vuexfire](https://vuefire.vuejs.org/api/vuexfire.html#firebaseaction) dejo de soportar esto (Antes funcionaba, pero entiendo que era necesario):
```js
markAsSeen: firebaseAction((notificationToken) =>
    markAsSeenApi(notificationToken),
  ),
```
Ya que tomaba notification token como el objeto entero que normalmente se desestructuraria si se necesitan mas cosas de la libreria.
```js
markAsSeen: firebaseAction(({},notificationToken) =>
    markAsSeenApi(notificationToken),
  ),
```


Tambien agregué el mail del sender en las notificaciones que lo tienen.