### PR TITLE
[backend] fix: return bitsplit email instead of splitwise email

### DIFF
--- a/app/helpers/api/v1/splitwise/debts_helper.rb
+++ b/app/helpers/api/v1/splitwise/debts_helper.rb
@@ -41,10 +41,19 @@ module Api::V1::Splitwise::DebtsHelper
           'first_name' => friend['first_name'],
           'last_name' => friend['last_name'],
           'picture' => friend['picture']['small'],
-          'email' => friend['email']
+          'email' => get_bitsplit_email(friend)
         }
     end
     user_info
+  end
+
+  def get_bitsplit_email(user)
+    if check_user_has_bitsplit user['id']
+      bitsplit_user = User.find_by(splitwise_user_id: user['id'])
+      return bitsplit_user.email
+    else
+      return user['email']
+    end
   end
 
   def check_user_has_bitsplit(user_id)


### PR DESCRIPTION
Retorna el mail de Bitsplit en vez del mail de Splitwise (sólo si el usuario de splitwise tiene cuenta en bitsplit)