### PR TITLE
[web] Payments history v2

### DIFF
--- a/app/javascript/api/payments-history.js
+++ b/app/javascript/api/payments-history.js
@@ -1,0 +1,6 @@
+/* eslint-disable camelcase */
+import { authedAxios } from '../helpers';
+
+const getPaymentsApi = () => authedAxios.get('/api/v2/transactions/');
+
+export { getPaymentsApi };

--- a/app/javascript/components/CustomTable.vue
+++ b/app/javascript/components/CustomTable.vue
@@ -1,6 +1,6 @@
 <template>
   <table class="table-auto bg-white sm:bg-white sm:shadow-lg">
-    <thead class="bg-indigo-500 text-white">
+    <thead class="bg-secondary text-white">
       <tr class="sm:table-row sm:mb-0">
         <th class="p-3" v-for="(column, index) in columns" :key="index">
           {{ column }}

--- a/app/javascript/components/CustomTable.vue
+++ b/app/javascript/components/CustomTable.vue
@@ -10,7 +10,7 @@
     <tbody class="sm:flex-none">
       <tr
         class="sm:table-row sm:mb-0"
-        v-for="(item, index) in data"
+        v-for="(item, index) in data.slice(0, limit)"
         :key="index"
       >
         <slot :row="item" :tdClass="tdClass" />
@@ -30,6 +30,7 @@ export default {
   props: {
     columns: Array,
     data: Array,
+    limit: { type: Number, default: Infinity },
   },
 };
 </script>

--- a/app/javascript/components/PaymentForm.vue
+++ b/app/javascript/components/PaymentForm.vue
@@ -133,6 +133,7 @@ export default {
     },
     handleSubmit() {
       const { amount, receiver_email } = this;
+      console.log(parseFloat(this.quotationBTC), receiver_email);
       if (amount && receiver_email) {
         this.sendPayment({
           payment_amount: parseFloat(this.quotationBTC),

--- a/app/javascript/components/PaymentForm.vue
+++ b/app/javascript/components/PaymentForm.vue
@@ -133,7 +133,6 @@ export default {
     },
     handleSubmit() {
       const { amount, receiver_email } = this;
-      console.log(parseFloat(this.quotationBTC), receiver_email);
       if (amount && receiver_email) {
         this.sendPayment({
           payment_amount: parseFloat(this.quotationBTC),

--- a/app/javascript/router/Home.vue
+++ b/app/javascript/router/Home.vue
@@ -31,8 +31,8 @@
       </div>
       <div>
         <div>
-          <p class="text-5xl font-bold">
-            Historial de Pagos
+          <p class="text-center text-xl font-bold mb-6">
+            Últimas 5 transacciones
           </p>
         </div>
         <div class="justify-start">
@@ -42,35 +42,57 @@
           <div v-else class="bg-gray-200 rounded-md">
             <div v-if="userPaymentsHistory.length">
               <CustomTable
-                :data="userPaymentsHistory.slice().reverse()"
+                :data="userPaymentsHistory"
                 :columns="tableColumns"
+                :limit="5"
               >
-                <template #default="{ row, tdClass }">
+                <template #default="{ row }">
                   <td
-                    :class="tdClass"
-                    v-if="row.attributes.sender_email != currentUser.email"
+                    class="border-grey-light border hover:bg-gray-100 p-3"
+                    v-if="row.attributes.sender.email != currentUser.email"
                   >
-                    <span>
+                    <span
+                      class="px-2 items-center inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"
+                    >
                       Recibido
                     </span>
                   </td>
-                  <td v-else :class="tdClass">
-                    <span>
+                  <td
+                    v-else
+                    class="border-grey-light border hover:bg-gray-100 p-3"
+                  >
+                    <span
+                      class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800"
+                    >
                       Enviado
                     </span>
                   </td>
-                  <td :class="tdClass">
-                    {{ row.attributes.sender_email }}
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.sender.email }}
                   </td>
-                  <td :class="tdClass">
-                    {{ row.attributes.receiver_email }}
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.receiver.email }}
                   </td>
-                  <td :class="tdClass">{{ row.attributes.amount }} BTC</td>
-                  <td :class="tdClass">
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.amount_btc }} BTC
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    $ {{ row.attributes.amount_clp.toFixed(0) }} CLP
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
                     {{ getDate(row.attributes.created_at) }}
                   </td>
                 </template>
               </CustomTable>
+              <div class="text-center px-4 py-2">
+                <LinkButton
+                  classmod="bg-blue-500 hover:bg-blue-700 my-3 md:my-0"
+                  :field-disabled="false"
+                  route="payments-history"
+                >
+                  Ver más
+                </LinkButton>
+              </div>
             </div>
             <div v-else>
               <p class="text-5xl font-bold">
@@ -286,15 +308,20 @@ export default {
   data() {
     return {
       routeName: 'home',
-      tableColumns: ['Tipo', 'Envía', 'Recibe', 'Cantidad', 'Fecha'],
+      tableColumns: [
+        'Tipo',
+        'Envía',
+        'Recibe',
+        'Cantidad BTC',
+        'Cantidad CLP',
+        'Fecha',
+      ],
       debtsColumns: ['De', 'Para', 'Monto', 'Pagar'],
     };
   },
   created() {
     this.getSplitwiseDebts();
-    if (this.budaSignedIn) {
-      this.getPayments();
-    }
+    this.getPayments();
   },
   components: {
     BudaAlert,
@@ -303,8 +330,10 @@ export default {
     CustomTable,
   },
   methods: {
-    ...mapActions('user', ['getPayments']),
+    ...mapActions('user', ['getUserBalance']),
     ...mapActions('splitwiseDebts', ['getSplitwiseDebts']),
+    ...mapActions('paymentsHistory', ['getPayments']),
+
     getDate(date) {
       const d = new Date(date);
 
@@ -312,15 +341,12 @@ export default {
     },
   },
   computed: {
-    ...mapState('user', [
-      'currentUser',
-      'getPaymentsLoading',
-      'userPaymentsHistory',
-    ]),
+    ...mapState('user', ['currentUser', 'getPaymentsLoading']),
     ...mapState('splitwiseDebts', [
       'getSplitwiseDebtsLoading',
       'userSplitwiseDebts',
     ]),
+    ...mapState('paymentsHistory', ['userPaymentsHistory']),
     ...mapGetters('user', ['budaSignedIn', 'splitwiseSignedIn']),
   },
 };

--- a/app/javascript/router/PaymentsHistory.vue
+++ b/app/javascript/router/PaymentsHistory.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="m-12 text-center txt-field">
+    <div v-if="!budaSignedIn">
+      <BudaAlert />
+    </div>
+    <div class="flex-col justify-start lg:flex-row p-10 rounded-md">
+      <div>
+        <div>
+          <p class="txt-field text-xl text-black font-bold mb-10">
+            Historial de transacciones
+          </p>
+        </div>
+        <div class="justify-start">
+          <div v-if="getPaymentsLoading">
+            <p>Cargando...</p>
+          </div>
+          <div v-else class="text-black rounded-md">
+            <div v-if="userPaymentsHistory.length">
+              <CustomTable :data="userPaymentsHistory" :columns="tableColumns">
+                <template #default="{ row }">
+                  <td
+                    class="border-grey-light border hover:bg-gray-100 p-3"
+                    v-if="row.attributes.sender.email != currentUser.email"
+                  >
+                    <span
+                      class="px-2 items-center inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800"
+                    >
+                      Recibido
+                    </span>
+                  </td>
+                  <td
+                    v-else
+                    class="border-grey-light border hover:bg-gray-100 p-3"
+                  >
+                    <span
+                      class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800"
+                    >
+                      Enviado
+                    </span>
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.sender.email }}
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.receiver.email }}
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ row.attributes.amount_btc }} BTC
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    $ {{ row.attributes.amount_clp.toFixed(0) }} CLP
+                  </td>
+                  <td class="border-grey-light border hover:bg-gray-100 p-3">
+                    {{ getDate(row.attributes.created_at) }}
+                  </td>
+                </template>
+              </CustomTable>
+            </div>
+            <div v-else>
+              <p class="text-5xl font-bold">
+                No hay pagos para mostrar
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState, mapGetters, mapActions } from 'vuex';
+import BudaAlert from 'components/BudaAlert.vue';
+import CustomTable from '../components/CustomTable';
+
+export default {
+  name: 'Home',
+  data() {
+    return {
+      routeName: 'home',
+      tableColumns: [
+        'Tipo',
+        'Envía',
+        'Recibe',
+        'Cantidad BTC',
+        'Cantidad CLP',
+        'Fecha',
+      ],
+    };
+  },
+  created() {
+    this.getPayments();
+  },
+  components: {
+    BudaAlert,
+    CustomTable,
+  },
+  methods: {
+    ...mapActions('user', ['getUserBalance']),
+    ...mapActions('paymentsHistory', ['getPayments']),
+
+    getDate(date) {
+      const d = new Date(date);
+
+      return d.toLocaleString('en-US', { hour12: false });
+    },
+  },
+  computed: {
+    ...mapState('user', ['currentUser', 'getPaymentsLoading']),
+    ...mapState('paymentsHistory', ['userPaymentsHistory']),
+    ...mapGetters('user', ['budaSignedIn', 'splitwiseSignedIn']),
+  },
+};
+</script>
+
+<style></style>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -9,6 +9,7 @@ import BudaIndex from './BudaIndex.vue';
 import PaymentIndex from './PaymentIndex.vue';
 import Profile from './Profile.vue';
 import OnBoarding from './OnBoarding.vue';
+import PaymentsHistory from './PaymentsHistory';
 
 import SplitwiseLink from '../components/profile/SplitwiseLink.vue';
 import ProfileHome from '../components/profile/ProfileHome.vue';
@@ -27,6 +28,11 @@ const router = new Router({
     { path: '/sign-up', component: SignUp, beforeEnter: checkNoAuth },
     { path: '/onboarding', component: OnBoarding, beforeEnter: checkAuth },
     { path: '/home', component: Home, beforeEnter: checkAuth },
+    {
+      path: '/payments-history',
+      component: PaymentsHistory,
+      beforeEnter: checkAuth,
+    },
     {
       path: '/profile/',
       component: Profile,

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -8,6 +8,7 @@ import component from './modules/component';
 import notification from './modules/notification';
 import onBoarding from './modules/onBoarding';
 import splitwiseDebts from './modules/splitwiseDebts';
+import paymentsHistory from './modules/paymentsHistory';
 
 Vue.use(Vuex);
 
@@ -19,6 +20,7 @@ const store = new Vuex.Store({
     notification,
     onBoarding,
     splitwiseDebts,
+    paymentsHistory,
   },
   mutations: vuexfireMutations,
 });

--- a/app/javascript/store/modules/paymentsHistory/index.js
+++ b/app/javascript/store/modules/paymentsHistory/index.js
@@ -20,8 +20,6 @@ const actions = {
     return getPaymentsApi(payload)
       .then(res => {
         commit(GET_PAYMENTS_SUCCESS, res.data.data.transactions);
-
-        return;
       })
       .catch(err => {
         commit(GET_PAYMENTS_FAIL);
@@ -31,10 +29,8 @@ const actions = {
             'Error obteniendo el historial de transacciones.',
             { root: true }
           );
-          throw new Error('Error obteniendo el historial de transacciones.');
         } else {
           dispatch('alert/errorAlert', 'Error desconocido.', { root: true });
-          throw new Error('Error desconocido');
         }
       });
   },

--- a/app/javascript/store/modules/paymentsHistory/index.js
+++ b/app/javascript/store/modules/paymentsHistory/index.js
@@ -1,0 +1,61 @@
+import { getPayments } from '../../action-types';
+
+import {
+  GET_PAYMENTS_ATTEMPT,
+  GET_PAYMENTS_FAIL,
+  GET_PAYMENTS_SUCCESS,
+} from '../../mutation-types';
+
+import { getPaymentsApi } from '../../../api/payments-history.js';
+
+const paymentsHistoryState = {
+  getPaymentsHistoryLoading: false,
+  userPaymentsHistory: [],
+};
+
+const actions = {
+  [getPayments]({ commit, dispatch }, payload) {
+    commit(GET_PAYMENTS_ATTEMPT);
+
+    return getPaymentsApi(payload)
+      .then(res => {
+        commit(GET_PAYMENTS_SUCCESS, res.data.data.transactions);
+
+        return;
+      })
+      .catch(err => {
+        commit(GET_PAYMENTS_FAIL);
+        if (err.response) {
+          dispatch(
+            'alert/errorAlert',
+            'Error obteniendo el historial de transacciones.',
+            { root: true }
+          );
+          throw new Error('Error obteniendo el historial de transacciones.');
+        } else {
+          dispatch('alert/errorAlert', 'Error desconocido.', { root: true });
+          throw new Error('Error desconocido');
+        }
+      });
+  },
+};
+
+const mutations = {
+  [GET_PAYMENTS_ATTEMPT](state) {
+    state.getPaymentsHistoryLoading = true;
+  },
+  [GET_PAYMENTS_FAIL](state) {
+    state.getPaymentsHistoryLoading = false;
+  },
+  [GET_PAYMENTS_SUCCESS](state, payments) {
+    state.getPaymentsHistoryLoading = false;
+    state.userPaymentsHistory = payments;
+  },
+};
+
+export default {
+  namespaced: true,
+  state: paymentsHistoryState,
+  actions,
+  mutations,
+};

--- a/app/javascript/store/modules/user/mutations.js
+++ b/app/javascript/store/modules/user/mutations.js
@@ -20,6 +20,7 @@ import {
   GET_PAYMENTS_ATTEMPT,
   GET_PAYMENTS_FAIL,
   GET_PAYMENTS_SUCCESS,
+  GET_DEBTS_SUCCESS,
 } from '../../mutation-types';
 
 export default {
@@ -104,5 +105,8 @@ export default {
   [GET_PAYMENTS_SUCCESS](state, payments) {
     state.getPaymentsLoading = false;
     state.userPaymentsHistory = payments;
+  },
+  [GET_DEBTS_SUCCESS](state, debts) {
+    state.userDebts = debts;
   },
 };

--- a/app/javascript/store/mutation-types.js
+++ b/app/javascript/store/mutation-types.js
@@ -37,5 +37,7 @@ export const SUCCESS_ALERT = 'SUCCESS_ALERT';
 export const ERROR_ALERT = 'ERROR_ALERT';
 export const CLEAR_ALERT = 'CLEAR_ALERT';
 
+export const GET_DEBTS_SUCCESS = 'GET_DEBTS_SUCCESS';
+
 export const NEXT_STEP = 'NEXT_STEP';
 export const PREVIOUS_STEP = 'PREVIOUS_STEP';


### PR DESCRIPTION
Se actualiza a la versión 2 del historial de transacciones:
- Se separa la llamada a la API
- Separé la lógica del estado en store
- Se crea una nueva página para ver el listado completo de transacciones
- Se ven solo las últimas 5 transacciones en el inicio.
- Ahora se ve también el valor en pesos chilenos de las transacciones

![image](https://user-images.githubusercontent.com/30701219/84035387-a26e0180-a969-11ea-8a41-dda23d1ce64a.png)
![image](https://user-images.githubusercontent.com/30701219/84035422-b0bc1d80-a969-11ea-8456-3f2746ebb6ad.png)
