### PR TITLE
[backend] add: Push Notifications associated with Sessions

### DIFF
--- a/app/controllers/api/v2/push_notifications_controller.rb
+++ b/app/controllers/api/v2/push_notifications_controller.rb
@@ -6,12 +6,10 @@ class Api::V2::PushNotificationsController < Api::V2::BaseController
     if token.nil?
       NotificationToken.create(:token => params[:token], :user => current_user, :authentication_token => auth_token)
       render json: { message: "push notification token saved" }, status: 200 and return
-    else
-      if token.user != current_user
-        token.update(:user => current_user)
-        token.update(:authentication_token => auth_token)
-        render json: { message: "push notification token updated" }, status: 200 and return
-      end
+    elsif token.user != current_user
+      token.update({:user => current_user,
+        :authentication_token => auth_token})
+      render json: { message: "push notification token updated" }, status: 200 and return
     end
     render json: { message: "token already exists" }, status: 409 and return
   end

--- a/app/controllers/api/v2/push_notifications_controller.rb
+++ b/app/controllers/api/v2/push_notifications_controller.rb
@@ -1,13 +1,19 @@
 class Api::V2::PushNotificationsController < Api::V2::BaseController
 
   def create
-    exists = NotificationToken.find_by(:token => params[:token], :user => current_user)
-    if exists.nil?
-      NotificationToken.create(:token => params[:token], :user => current_user)
+    token = NotificationToken.find_by(:token => params[:token])
+    auth_token = Tiddle::TokenIssuer.build.find_token(current_user, request.headers['X-User-Token'])
+    if token.nil?
+      NotificationToken.create(:token => params[:token], :user => current_user, :authentication_token => auth_token)
       render json: { message: "push notification token saved" }, status: 200 and return
     else
-      render json: { message: "token already exists" }, status: 409 and return
+      if token.user != current_user
+        token.update(:user => current_user)
+        token.update(:authentication_token => auth_token)
+        render json: { message: "push notification token updated" }, status: 200 and return
+      end
     end
+    render json: { message: "token already exists" }, status: 409 and return
   end
 
   private

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -1,6 +1,6 @@
 class AuthenticationToken < ApplicationRecord
   belongs_to :user
-  has_one :notification_token, dependent: :delete
+  has_one :notification_token, dependent: :destroy
 end
 
 # == Schema Information

--- a/app/models/authentication_token.rb
+++ b/app/models/authentication_token.rb
@@ -1,5 +1,6 @@
 class AuthenticationToken < ApplicationRecord
   belongs_to :user
+  has_one :notification_token, dependent: :delete
 end
 
 # == Schema Information

--- a/app/models/notification_token.rb
+++ b/app/models/notification_token.rb
@@ -1,3 +1,4 @@
 class NotificationToken < ApplicationRecord
   belongs_to :user
+  belongs_to :authentication_token
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :sent_payments, class_name: 'Payment', foreign_key: 'sender_id'
   has_many :received_payments, class_name: 'Payment', foreign_key: 'receiver_id'
   has_many :authentication_tokens, dependent: :delete_all
+  has_many :notification_tokens, dependent: :delete_all
 
   def wallet_balance
     wallet_account&.balance || Money.from_amount(0, 'SAT')

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -13,18 +13,19 @@ class PushNotificationService < PowerTypes::Service.new
   end
 
   def payment_notification
-    messages = []
-    @tokens.each do |token|
-      messages.push(payment_message(token.token))
+    if @user.notification_tokens.any?
+      messages = []
+      @user.notification_tokens.each do |token|
+        messages.push(payment_message(token.token))
+      end
+      send_notification("payment", messages)
     end
-    send_notification("payment", messages)
   end
 
   private
 
   def initialize(user)
     @user = user
-    @tokens = NotificationToken.where(user: @user)
     @push_client =  Exponent::Push::Client.new
   end
 end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -13,13 +13,13 @@ class PushNotificationService < PowerTypes::Service.new
   end
 
   def payment_notification
-    if @user.notification_tokens.any?
-      messages = []
-      @user.notification_tokens.each do |token|
-        messages.push(payment_message(token.token))
-      end
-      send_notification("payment", messages)
+    return unless @user.notification_tokens.any?
+    
+    messages = []
+    @user.notification_tokens.each do |token|
+      messages.push(payment_message(token.token))
     end
+    send_notification("payment", messages)
   end
 
   private

--- a/db/migrate/20200616011930_add_authentication_token_to_notification_token.rb
+++ b/db/migrate/20200616011930_add_authentication_token_to_notification_token.rb
@@ -1,0 +1,7 @@
+class AddAuthenticationTokenToNotificationToken < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :notification_tokens, :authentication_token, null: false, foreign_key: true, index: {algorithm: :concurrently}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_09_162246) do
+ActiveRecord::Schema.define(version: 2020_06_16_011930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -134,6 +134,8 @@ ActiveRecord::Schema.define(version: 2020_06_09_162246) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "authentication_token_id", null: false
+    t.index ["authentication_token_id"], name: "index_notification_tokens_on_authentication_token_id"
     t.index ["user_id"], name: "index_notification_tokens_on_user_id"
   end
 
@@ -207,6 +209,7 @@ ActiveRecord::Schema.define(version: 2020_06_09_162246) do
   add_foreign_key "deposits", "users"
   add_foreign_key "ledgerizer_lines", "ledgerizer_accounts", column: "account_id"
   add_foreign_key "ledgerizer_lines", "ledgerizer_entries", column: "entry_id"
+  add_foreign_key "notification_tokens", "authentication_tokens"
   add_foreign_key "notification_tokens", "users"
   add_foreign_key "payments", "users", column: "receiver_id"
   add_foreign_key "payments", "users", column: "sender_id"


### PR DESCRIPTION
Ahora los tokens de notificaciones están asociados a los tokens de autenticación, de forma que solo envíe notificaciones push cuando la sesión sea válida. (Ej. no envíe notificaciones si se cerró la sesión en el celular, cambio de celular, etc).

Permite manejar los siguientes casos:

- Usuario Borra la app/datos de la app
- Distinto usuario en el mismo teléfono
- Mismo usuario en otro teléfono
