### PR TITLE
Buda Direct Withdraw

### DIFF
--- a/app/controllers/api/v2/buda_withdrawals_controller.rb
+++ b/app/controllers/api/v2/buda_withdrawals_controller.rb
@@ -1,0 +1,45 @@
+class Api::V2::BudaWithdrawalsController < ApplicationController
+  
+  def create
+    if current_user.api_key && !decrypt(current_user.api_key).empty?
+      api_key, api_secret = current_user.buda_keys
+      buda_service = BudaUserService.new(api_key: api_key, api_secret: api_secret)
+      @invoice = buda_service.generate_invoice(params[:amount])
+      satoshis_amount = satoshi_price(params[:amount])
+      money_service = MoneyService.new
+      amount_validation, message = money_service.validate_amount(current_user, satoshis_amount)
+      @response = message
+      return unless amount_validation
+      new_user_withdrawal = UserWithdrawal.create!(user_id: current_user.id,
+                                            amount: params[:amount], 
+                                            completed: false,
+                                            invoice: @invoice )
+      response = opennode_service.send_withdrawal_request(@invoice, false)
+      @response = JSON.parse(response.body)
+    else
+      render(json: { error: 'user does not have synchronized Buda' }, status: 400) 
+    end
+  end
+
+  private
+
+  def buda_withdrawals_params
+    params.permit(:amount)
+  end
+
+  def satoshi_price(bitcoins_amount)
+    (bitcoins_amount * 100_000_000).round
+  end
+
+  def decrypt(text)
+    if text.nil?
+      nil
+    else
+      salt, data = text.split '$$'
+      len   = ActiveSupport::MessageEncryptor.key_len
+      key   = ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base).generate_key salt, len
+      crypt = ActiveSupport::MessageEncryptor.new key
+      crypt.decrypt_and_verify data
+    end
+  end
+end

--- a/app/controllers/api/v2/buda_withdrawals_controller.rb
+++ b/app/controllers/api/v2/buda_withdrawals_controller.rb
@@ -4,18 +4,21 @@ class Api::V2::BudaWithdrawalsController < ApplicationController
     if current_user.api_key && !decrypt(current_user.api_key).empty?
       api_key, api_secret = current_user.buda_keys
       buda_service = BudaUserService.new(api_key: api_key, api_secret: api_secret)
-      @invoice = buda_service.generate_invoice(params[:amount])
+      response = buda_service.generate_invoice(params[:amount])
+      invoice = JSON.parse(response.body)['invoice']['encoded_payment_request']
       satoshis_amount = satoshi_price(params[:amount])
       money_service = MoneyService.new
+      render(json: { error: 'invalid buda invoice' }, status: 400) and return unless money_service.check_buda_invoice_creation(response)
       amount_validation, message = money_service.validate_amount(current_user, satoshis_amount)
-      @response = message
-      return unless amount_validation
+      render(json: { error: message }, status: 400) and return unless amount_validation
       new_user_withdrawal = UserWithdrawal.create!(user_id: current_user.id,
                                             amount: params[:amount], 
                                             completed: false,
-                                            invoice: @invoice )
-      response = opennode_service.send_withdrawal_request(@invoice, false)
-      @response = JSON.parse(response.body)
+                                            invoice: invoice )
+      opennode_service = OpenNodeService.new
+      response = opennode_service.send_withdrawal_request(invoice, false)
+      render(json: { error: 'invalid opennode withdrawal request' }, status: 400) and return unless money_service.check_opennode_response(response)
+      render(json: JSON.parse(response.body), status: 200) and return
     else
       render(json: { error: 'user does not have synchronized Buda' }, status: 400) 
     end

--- a/app/controllers/api/v2/buda_withdrawals_controller.rb
+++ b/app/controllers/api/v2/buda_withdrawals_controller.rb
@@ -16,7 +16,7 @@ class Api::V2::BudaWithdrawalsController < ApplicationController
                                             completed: false,
                                             invoice: invoice )
       opennode_service = OpenNodeService.new
-      response = opennode_service.send_withdrawal_request(invoice, false)
+      response = opennode_service.send_withdrawal_request(invoice, true)
       render(json: { error: 'invalid opennode withdrawal request' }, status: 400) and return unless money_service.check_opennode_response(response)
       render(json: JSON.parse(response.body), status: 200) and return
     else

--- a/app/controllers/api/v2/buda_withdrawals_controller.rb
+++ b/app/controllers/api/v2/buda_withdrawals_controller.rb
@@ -20,10 +20,6 @@ class Api::V2::BudaWithdrawalsController < ApplicationController
     params.permit(:amount)
   end
 
-  def satoshi_price(bitcoins_amount)
-    (bitcoins_amount * 100_000_000).round
-  end
-
   def decrypt(text)
     if text.nil?
       nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       resource :depositwebhooks, only: [:create]
       resource :buda_pays, only: [:create]
       resource :withdrawals_webhook, only: [:create]
-
+      resource :buda_withdrawals, only: [:create]
     end
   end
   


### PR DESCRIPTION
Endpoint para retiros automáticos hacia buda (para no tener que copiar y pegar invoices a mano)
-Nueva ruta /api/v2/buda_withdrawals
-Crea invoice con la API de Buda
-Paga invoice con la API de OpenNode