### PR TITLE
Buda direct

### DIFF
--- a/app/javascript/api/wallet.js
+++ b/app/javascript/api/wallet.js
@@ -30,4 +30,20 @@ const budaWidthdrawalApi = payload => {
   });
 };
 
-export { depositApi, widthdrawalApi, budaWidthdrawalApi };
+const budaDirectInvoicePayApi = payload => {
+  const { invoice, order_id } = payload;
+
+  if (!invoice || !order_id) return Promise.reject('Error');
+
+  return authedAxios.post('/api/v2/buda_pays', {
+    invoice,
+    order_id,
+  });
+};
+
+export {
+  depositApi,
+  widthdrawalApi,
+  budaWidthdrawalApi,
+  budaDirectInvoicePayApi,
+};

--- a/app/javascript/api/wallet.js
+++ b/app/javascript/api/wallet.js
@@ -20,5 +20,14 @@ const widthdrawalApi = payload => {
     invoice,
   });
 };
+const budaWidthdrawalApi = payload => {
+  const { amount } = payload;
 
-export { depositApi, widthdrawalApi };
+  if (!amount) return Promise.reject('Error');
+
+  return authedAxios.post('/api/v2/buda_withdrawals', {
+    amount,
+  });
+};
+
+export { depositApi, widthdrawalApi, budaWidthdrawalApi };

--- a/app/javascript/components/profile/ProfileOpenNode.vue
+++ b/app/javascript/components/profile/ProfileOpenNode.vue
@@ -53,31 +53,65 @@
       <text-field font-size="full">
         Retirar de Bitsplit
       </text-field>
-      <InputLabel>
-        Crea un invoice con el monto que quieras retirar y nosotros lo pagamos.
-      </InputLabel>
-      <form
-        @submit.prevent="handleWithdrawalSubmit"
-        class="flex flex-col md:flex-row"
-      >
-        <div class="md:mr-2 mb-2 flex-grow">
-          <textInput
-            field-id="invoice"
-            field-type="text"
-            field-placeholder="Ingresa el invoice aqui "
-            field-name="invoice"
-            v-model="invoice"
-          />
-        </div>
-        <submitButton :loading="withdrawalAllowed">
-          Retirar
-        </submitButton>
-      </form>
+      <div>
+        <InputLabel>
+          Crea un invoice con el monto que quieras retirar y nosotros lo
+          pagamos.
+        </InputLabel>
+        <form
+          @submit.prevent="handleWithdrawalSubmit"
+          class="flex flex-col md:flex-row"
+        >
+          <div class="md:mr-2 mb-2 flex-grow">
+            <textInput
+              field-id="invoice"
+              field-type="text"
+              field-placeholder="Ingresa el invoice aqui "
+              field-name="invoice"
+              v-model="invoice"
+            />
+          </div>
+          <submitButton :loading="withdrawalAllowed">
+            Retirar
+          </submitButton>
+        </form>
+      </div>
+      <div class="pt-4" v-if="budaSignedIn">
+        <InputLabel>
+          Retirar directamente a tu cuenta de Buda.
+        </InputLabel>
+        <form
+          @submit.prevent="handleWithdrawalDirectSubmit"
+          class="flex flex-col md:flex-row"
+        >
+          <div class="md:mr-2 mb-2 flex-grow">
+            <textInput
+              field-id="budaWithdrawalDirect"
+              field-type="number"
+              field-placeholder="0.12"
+              field-name="budaWithdrawalDirect"
+              v-model="budaWithdrawalDirect"
+            />
+          </div>
+          <div class="mx-2">
+            <select-input
+              field-name="currency"
+              field-id="currency"
+              v-model="currency"
+              :options="currencyOptions"
+              :name-mappings="nameMappings"
+            />
+          </div>
+          <submitButton :loading="directWithdrawallAllowed">
+            Retirar
+          </submitButton>
+        </form>
+      </div>
     </div>
   </div>
 </template>
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapState, mapGetters } from 'vuex';
 import QrcodeVue from 'qrcode.vue';
 
 import TextField from '../TextField';
@@ -103,17 +137,27 @@ export default {
       amount: '',
       currency: 'BTC',
       invoice: '',
+      budaWithdrawalDirect: '',
       loading: false,
       showDepositInvoice: false,
       depositInvoice: null,
     };
   },
   computed: {
+    ...mapState('user', ['userBalanceBitsplitBTC']),
+    ...mapGetters('user', ['budaSignedIn']),
     depositAllowed() {
       return this.loading || !(this.amount && this.currency);
     },
     withdrawalAllowed() {
       return this.loading || !this.invoice;
+    },
+    directWithdrawallAllowed() {
+      if (this.userBalanceBitsplitBTC < parseFloat(this.budaWithdrawalDirect)) {
+        return true;
+      }
+
+      return this.loading || !this.budaWithdrawalDirect;
     },
   },
   methods: {
@@ -145,6 +189,20 @@ export default {
         .catch(() => {
           this.loading = false;
         });
+    },
+    handleWithdrawalDirectSubmit() {
+      // this.loading = true;
+
+      const { budaWithdrawalDirect } = this;
+      console.log(budaWithdrawalDirect);
+
+      // return this.withdrawalOpenNode({ invoice })
+      //   .then(() => {
+      //     this.loading = false;
+      //   })
+      //   .catch(() => {
+      //     this.loading = false;
+      //   });
     },
     setShowDepositInvoice(invoice) {
       this.showDepositInvoice = true;

--- a/app/javascript/store/action-types.js
+++ b/app/javascript/store/action-types.js
@@ -32,6 +32,7 @@ export const updateCurrentUser = 'updateCurrentUser';
 
 export const depositOpenNode = 'depositOpenNode';
 export const withdrawalOpenNode = 'withdrawalOpenNode';
+export const budaDirectWithdrawal = 'budaDirectWithdrawal';
 
 export const sendRecoveryEmail = 'sendRecoveryEmail';
 export const passwordRecovery = 'passwordRecovery';

--- a/app/javascript/store/action-types.js
+++ b/app/javascript/store/action-types.js
@@ -33,6 +33,7 @@ export const updateCurrentUser = 'updateCurrentUser';
 export const depositOpenNode = 'depositOpenNode';
 export const withdrawalOpenNode = 'withdrawalOpenNode';
 export const budaDirectWithdrawal = 'budaDirectWithdrawal';
+export const budaDirectInvoicePay = 'budaDirectInvoicePay';
 
 export const sendRecoveryEmail = 'sendRecoveryEmail';
 export const passwordRecovery = 'passwordRecovery';

--- a/app/javascript/store/modules/user/actions.js
+++ b/app/javascript/store/modules/user/actions.js
@@ -18,6 +18,7 @@ import {
   sendRecoveryEmail,
   passwordRecovery,
   budaDirectWithdrawal,
+  budaDirectInvoicePay,
 } from '../../action-types';
 
 import {
@@ -71,6 +72,7 @@ import {
   widthdrawalApi,
   depositApi,
   budaWidthdrawalApi,
+  budaDirectInvoicePayApi,
 } from '../../../api/wallet';
 
 import { validateEmail } from '../../../helpers';
@@ -671,6 +673,29 @@ export default {
   },
   [budaDirectWithdrawal]({ dispatch }, payload) {
     return budaWidthdrawalApi(payload)
+      .then(() => {
+        dispatch('alert/successAlert', '¡Se ha hecho el deposito con exito!', {
+          root: true,
+        });
+
+        return;
+      })
+      .catch(error => {
+        if (error.response) {
+          dispatch('alert/errorAlert', 'Revisa tu saldo o tus datos de Buda', {
+            root: true,
+          });
+        } else {
+          dispatch('alert/errorAlert', 'Error desconocido', {
+            root: true,
+          });
+        }
+
+        throw Error(error);
+      });
+  },
+  [budaDirectInvoicePay]({ dispatch }, payload) {
+    return budaDirectInvoicePayApi(payload)
       .then(() => {
         dispatch('alert/successAlert', '¡Se ha hecho el deposito con exito!', {
           root: true,

--- a/app/javascript/store/modules/user/actions.js
+++ b/app/javascript/store/modules/user/actions.js
@@ -17,6 +17,7 @@ import {
   withdrawalOpenNode,
   sendRecoveryEmail,
   passwordRecovery,
+  budaDirectWithdrawal,
 } from '../../action-types';
 
 import {
@@ -66,10 +67,13 @@ import {
   passwordRecoveryApi,
 } from '../../../api/user.js';
 
-import { widthdrawalApi, depositApi } from '../../../api/wallet';
+import {
+  widthdrawalApi,
+  depositApi,
+  budaWidthdrawalApi,
+} from '../../../api/wallet';
 
 import { validateEmail } from '../../../helpers';
-
 
 const commitAndSetUser = ({ commit, mutation, user }) => {
   if (user) {
@@ -658,6 +662,29 @@ export default {
           });
         } else {
           dispatch('alert/errorAlert', 'Falta el endpoint en el backend', {
+            root: true,
+          });
+        }
+
+        throw Error(error);
+      });
+  },
+  [budaDirectWithdrawal]({ dispatch }, payload) {
+    return budaWidthdrawalApi(payload)
+      .then(() => {
+        dispatch('alert/successAlert', '¡Se ha hecho el deposito con exito!', {
+          root: true,
+        });
+
+        return;
+      })
+      .catch(error => {
+        if (error.response) {
+          dispatch('alert/errorAlert', 'Revisa tu saldo o tus datos de Buda', {
+            root: true,
+          });
+        } else {
+          dispatch('alert/errorAlert', 'Error desconocido', {
             root: true,
           });
         }


### PR DESCRIPTION
Se da la opcion a los usuarios de ingresar plata directamente a bitsplit desde su cuenta de buda, saltandose el paso de tener que ir a la aplicaicion y pagar el invoice ahi.

Las opciones solo aparecen cuando se tiene buda seteado.
![image](https://user-images.githubusercontent.com/26393563/85935053-007f6c00-b8ba-11ea-8ace-8821e4c44516.png)
![image](https://user-images.githubusercontent.com/26393563/85935056-0d03c480-b8ba-11ea-8757-01a2ff5aed0c.png)

