### PR TITLE
[web] Actualización de pagos y pequeñas correcciones de estilo

### DIFF
--- a/app/javascript/components/payment/PaymentForm.vue
+++ b/app/javascript/components/payment/PaymentForm.vue
@@ -266,7 +266,7 @@ export default {
             this.currency_selected = 'btc';
           }
           else {
-            if (this.userBalanceBudaBTC) {
+            if (this.budaSignedIn && this.userBalanceBudaBTC) {
               wallet = 'buda'
             }
             else {

--- a/app/javascript/components/payment/PaymentForm.vue
+++ b/app/javascript/components/payment/PaymentForm.vue
@@ -48,12 +48,30 @@
       </div>
       <form @submit.prevent="handleSubmit">
         <div class="flex flex-col mb-6 mt-6">
-          <label class="block text-gray-700 text-lg py-2" for="account_balance"
-            >Wallet desde la que se enviará el pago:
-            {{
-              currentWallet() | capitalize
-            }}
-          </label>
+          <div v-if="this.getBalanceLoading">
+            <span
+              class="block text-gray-700 text-lg py-2"
+            >
+              Cargando tu saldo...
+            </span>
+          </div>
+          <div v-else>
+            <span
+              v-if="this.userBalanceBitsplitBTC || this.userBalanceBudaBTC"
+              class="block text-gray-700 text-lg py-2"
+            >
+              Wallet desde la que se enviará el pago:
+              {{
+                currentWallet() | capitalize
+              }}
+            </span>
+            <span
+              v-else
+              class="block text-gray-700 text-lg py-2"
+            >
+              No hay saldo en ninguna de tus wallet :(
+            </span>
+          </div>
           <select v-if="budaSignedIn"
             class="txt-input appearance-none border rounded w-full my-4 py-2 px-3 leading-tight"
             v-model="wallet_origin_selected"
@@ -61,10 +79,10 @@
             <option value="" disabled selected>
               Cambiar Wallet
             </option>
-            <option value="bitsplit">
+            <option value="bitsplit" :disabled="!this.userBalanceBitsplitBTC">
               Bitsplit
             </option>
-            <option value="buda">
+            <option value="buda" :disabled="!this.userBalanceBudaBTC">
               Buda
             </option>
           </select>
@@ -95,7 +113,7 @@
         </div>
         <div class="flex flex-col mb-6 mt-6">
           <div class="flex flex-col">
-            <label class="block mt-4 text-gray-700 text-lg" for="account_balance"
+            <label class="block text-gray-700 text-lg" for="account_balance"
               >Equivalente a:</label
             >
             <label
@@ -171,6 +189,7 @@ export default {
     ...mapState('user', [
       'currentUser',
       'sendPaymentLoading',
+      'getBalanceLoading',
       'userBalanceBudaCLP',
       'userBalanceBudaBTC',
       'userBalanceBudaBTCCLP',
@@ -192,6 +211,13 @@ export default {
         this.debounceEmail()
       }
     },
+    currency_selected: {
+      handler: function() {
+        this.amount = '';
+        this.quotationCLP = 0;
+        this.quotationBTC = 0;
+      }
+    }
   },
   filters: {
     capitalize: function (value) {
@@ -228,10 +254,41 @@ export default {
       }
     },
     currentWallet() {
-      const wallet = this.wallet_origin_selected
-        ? this.wallet_origin_selected
-        : this.currentUser.wallet;
-      if (wallet === 'bitsplit') this.currency_selected = 'btc';
+      var wallet;
+
+      if (this.wallet_origin_selected) {
+        wallet = this.wallet_origin_selected
+      }
+      else {
+        if (this.currentUser.wallet === 'bitsplit') {
+          if (this.userBalanceBitsplitBTC) {
+            wallet = 'bitsplit'
+            this.currency_selected = 'btc';
+          }
+          else {
+            if (this.userBalanceBudaBTC) {
+              wallet = 'buda'
+            }
+            else {
+              wallet = null
+            }
+          }
+        }
+        else if (this.currentUser.wallet === 'buda') {
+          if (this.userBalanceBudaBTC) {
+            wallet = 'buda'
+          }
+          else {
+            if (this.userBalanceBitsplitBTC) {
+              wallet = 'bitsplit'
+              this.currency_selected = 'btc';
+            }
+            else {
+              wallet = null
+            }
+          }
+        }
+      }
 
       return wallet;
     },
@@ -244,7 +301,7 @@ export default {
                                 ? userBalanceBitsplitBTC 
                                 : userBalanceBudaBTC
 
-      return walletBalanceBTC >= paymentAmountBTC
+      return wallet && walletBalanceBTC >= paymentAmountBTC
     },
     paymentAmountBTC() {
       const { amount, quotationBTC, currency_selected } = this;

--- a/app/javascript/components/payment/PaymentForm.vue
+++ b/app/javascript/components/payment/PaymentForm.vue
@@ -94,7 +94,7 @@
           </div>
         </div>
         <div class="flex flex-col mb-6 mt-6">
-          <div v-if="currency_selected === 'clp'" class="flex flex-col">
+          <div class="flex flex-col">
             <label class="block mt-4 text-gray-700 text-lg" for="account_balance"
               >Equivalente a:</label
             >
@@ -103,7 +103,7 @@
               for="account_balance"
               >{{ quotationCLP }} CLP</label
             >
-            <label
+            <label v-if="currency_selected === 'clp'"
               class="mb-4 uppercase font-bold text-xl text-indigo-600"
               for="account_balance"
               >{{ quotationBTC }} BTC</label
@@ -135,7 +135,9 @@ import submitButton from '../SubmitButton';
 import spinner from '../Spinner';
 
 const DEBOUNCE_TIMER = 1500;
-const MIN_QUOTATION = 200;
+const MIN_QUOTATION_CLP = 200;
+const BTC_QUOTATION_BASE = 1000;
+const CLP_DECIMALS = 2;
 
 export default {
   name: 'Payment',
@@ -203,19 +205,26 @@ export default {
     ...mapActions('component', ['changePaymentComp']),
     getNewQuotation() {
       const { amount } = this;
-      if (amount >= MIN_QUOTATION && this.currency_selected === 'clp') {
-        this.getQuotation({ amount })
-          .then(balance => {
-            this.quotationCLP = balance.amount_clp[0];
-            this.quotationBTC = balance.amount_btc[0];
-          })
-          .catch(err => {
-            console.error(err);
-          });
-      }
-      else {
-        this.quotationCLP = 0
-        this.quotationBTC = 0
+      if (amount) {
+        if (this.currency_selected === 'clp' && amount >= MIN_QUOTATION_CLP) {
+          this.getQuotation({ amount })
+            .then(balance => {
+              this.quotationCLP = balance.amount_clp[0];
+              this.quotationBTC = balance.amount_btc[0];
+            })
+            .catch(err => {
+              console.error(err);
+            });
+        }
+        else if (this.currency_selected === 'btc') {
+          this.getQuotation({ amount: BTC_QUOTATION_BASE })
+            .then(balance => {
+              this.quotationCLP = ((amount * BTC_QUOTATION_BASE) / balance.amount_btc[0]).toFixed(CLP_DECIMALS);
+            })
+            .catch(err => {
+              console.error(err);
+            });
+        }
       }
     },
     currentWallet() {

--- a/app/javascript/components/payment/PaymentForm.vue
+++ b/app/javascript/components/payment/PaymentForm.vue
@@ -104,7 +104,7 @@
                 <option value="btc">
                   BTC
                 </option>
-                <option v-if="currentWallet() === 'buda'" value="clp">
+                <option value="clp">
                   CLP
                 </option>
               </select>

--- a/app/javascript/components/profile/ProfileHome.vue
+++ b/app/javascript/components/profile/ProfileHome.vue
@@ -36,7 +36,7 @@
         </div>
         <div v-else>
           <p class="text-grey-dark mb-4 mt-4">
-            Aun no estas sincronizado con Buda!
+            Aún no estás sincronizado con Buda!
           </p>
         </div>
       </div>

--- a/app/javascript/components/splitwisePayment/SplitwisePaymentForm.vue
+++ b/app/javascript/components/splitwisePayment/SplitwisePaymentForm.vue
@@ -256,7 +256,7 @@ export default {
             wallet = 'bitsplit'
           }
           else {
-            if (budaBalance) {
+            if (this.budaSignedIn && budaBalance) {
               wallet = 'buda'
             }
           }
@@ -289,7 +289,7 @@ export default {
       const paymentAmountBTC = this.paymentAmountBTC()
       const { userBalanceBudaBTC, budaSignedIn } = this
 
-      return budaSignedIn && userBalanceBudaBTC >= paymentAmountBTC
+      return userBalanceBudaBTC >= paymentAmountBTC
     },
     checkBitsplitBalance() {
       const paymentAmountBTC = this.paymentAmountBTC()

--- a/app/javascript/components/splitwisePayment/SplitwisePaymentForm.vue
+++ b/app/javascript/components/splitwisePayment/SplitwisePaymentForm.vue
@@ -248,7 +248,7 @@ export default {
             wallet = 'bitsplit'
           }
           else {
-            if (this.userBalanceBudaBTC) {
+            if (this.budaSignedIn && this.userBalanceBudaBTC) {
               wallet = 'buda'
             }
             else {

--- a/app/javascript/router/Home.vue
+++ b/app/javascript/router/Home.vue
@@ -31,7 +31,7 @@
         </div>
         <div class="justify-start">
           <div v-if="getPaymentsLoading">
-            <p>Cargando...</p>
+            <spinner />
           </div>
           <div v-else class="bg-gray-200 rounded-md">
             <div v-if="userPaymentsHistory.length">
@@ -106,6 +106,7 @@ import submitButton from '../components/SubmitButton';
 import linkButton from '../components/LinkButton';
 import UserCard from '../components/UserCard';
 import CustomTable from '../components/CustomTable';
+import spinner from '../components/Spinner';
 
 export default {
   name: 'Home',
@@ -130,6 +131,7 @@ export default {
     linkButton,
     UserCard,
     CustomTable,
+    spinner,
   },
   methods: {
     ...mapActions('paymentsHistory', ['getPayments']),

--- a/app/javascript/router/PaymentsHistory.vue
+++ b/app/javascript/router/PaymentsHistory.vue
@@ -12,7 +12,7 @@
         </div>
         <div class="justify-start">
           <div v-if="getPaymentsLoading">
-            <p>Cargando...</p>
+            <spinner />
           </div>
           <div v-else class="text-black rounded-md">
             <div v-if="userPaymentsHistory.length">
@@ -72,6 +72,7 @@
 import { mapState, mapGetters, mapActions } from 'vuex';
 import BudaAlert from 'components/buda/BudaAlert.vue';
 import CustomTable from '../components/CustomTable';
+import spinner from '../components/Spinner';
 
 export default {
   name: 'Home',
@@ -94,6 +95,7 @@ export default {
   components: {
     BudaAlert,
     CustomTable,
+    spinner,
   },
   methods: {
     ...mapActions('paymentsHistory', ['getPayments']),

--- a/app/javascript/router/SplitwiseConnectionReady.vue
+++ b/app/javascript/router/SplitwiseConnectionReady.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="items-center h-screen w-full bg-primary p-12 mt-24 text-center">
     <text-field font-size="full">
-      ¡Ya estas conectado con Splitwise!
+      ¡Ya estás conectado con Splitwise!
     </text-field>
     <text-field font-color="secondary">
       Cierra esta pestaña o dirígete a Bitsplit para continuar

--- a/app/javascript/router/SplitwiseIndex.vue
+++ b/app/javascript/router/SplitwiseIndex.vue
@@ -7,7 +7,7 @@
         </span>
       </div>
       <div v-if="getSplitwiseDebtsLoading">
-        <p>Cargando...</p>
+        <spinner />
       </div>
       <div v-else class="rounded-md">
         <div
@@ -170,6 +170,7 @@
 <script>
 import { mapState, mapGetters, mapActions } from 'vuex';
 import linkButton from '../components/LinkButton';
+import spinner from '../components/Spinner';
 
 export default {
   name: 'Home',
@@ -184,6 +185,7 @@ export default {
   },
   components: {
     linkButton,
+    spinner,
   },
   methods: {
     ...mapActions('splitwiseDebts', ['getSplitwiseDebts']),

--- a/app/javascript/router/SplitwiseIndex.vue
+++ b/app/javascript/router/SplitwiseIndex.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex justify-center m-8">
     <div>
-      <div class="text-grey-darker mb-2">
-        <span class="text-xl flex justify-center align-top text-indigo-600"
+      <div class="text-grey-darker mb-6">
+        <span class="text-black text-xl leading-none mb-10 mt-4 font-bold"
           >Deudas de Splitwise
         </span>
       </div>
@@ -16,7 +16,7 @@
         
           <div v-if="userSplitwiseDebts.singleDebts">
             <div class="text-grey-darker">
-              <span class="text-lg align-top text-blue-800">Deudas Individuales</span>
+              <span class="text-blue-800 text-lg leading-none mb-4 mt-4 font-bold">Deudas Individuales</span>
             </div>
             <div>
               <div
@@ -90,7 +90,7 @@
               :key="index"
             >
               <div class="text-grey-darker">
-                <span class="text-lg align-top text-blue-800">{{ group.group_name }}</span>
+                <span class="text-blue-800 text-lg leading-none mb-4 mt-4 font-bold">{{ group.group_name }}</span>
               </div>
               <div>
                 <div

--- a/app/javascript/router/SplitwiseIndex.vue
+++ b/app/javascript/router/SplitwiseIndex.vue
@@ -58,7 +58,7 @@
                   </div>
                 </div>
                 <div 
-                  v-if="single_debt.is_payable && !single_debt.type" 
+                  v-if="!single_debt.type" 
                   class="flex-column content-center bg-indigo-800 ml-auto"
                 >
                   <linkButton

--- a/app/javascript/store/modules/user/mutations.js
+++ b/app/javascript/store/modules/user/mutations.js
@@ -79,7 +79,7 @@ export default {
     state.getBalanceLoading = true;
   },
   [GET_USER_BALANCE_SUCCESS](state, balance) {
-    state.getBalanceLoading = true;
+    state.getBalanceLoading = false;
     state.userBalanceBudaCLP = parseFloat(balance.buda.CLP.available_amount);
     state.userBalanceBudaBTC = parseFloat(balance.buda.BTC.available_amount);
     state.userBalanceBudaBTCCLP = parseInt(


### PR DESCRIPTION
1. Ahora al ingresar un monto a enviar en BTC, se muestra el monto equivalente en CLP.
![image](https://user-images.githubusercontent.com/37151952/86153414-a6f08a80-bacf-11ea-86f1-ef8929bcea43.png)

2. Si el usuario no tiene saldo en su wallet por defecto, se seleccionará la wallet alternativa como base para enviar el pago en caso de que esta sí tenga. Si el usuario no tiene saldo en ninguna de sus wallets, se muestra el mensaje respectivo.

3. Se cambiaron los mensajes de cargando por spinners.
![image](https://user-images.githubusercontent.com/37151952/86153336-83c5db00-bacf-11ea-80cd-69dcd63aa626.png)

4. Se hicieron pequeñas correcciones de texto y estilo.