### PR TITLE
[web] add: supported currencies on splitwise debts

### DIFF
--- a/app/javascript/router/SplitwiseIndex.vue
+++ b/app/javascript/router/SplitwiseIndex.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex justify-center m-8">
+  <div class="flex justify-center m-10">
     <div>
       <div class="text-grey-darker mb-6">
         <span class="text-black text-xl leading-none mb-10 mt-4 font-bold"
@@ -48,17 +48,17 @@
                     <span
                       v-if="single_debt.type"
                     >
-                      Te deben ${{ single_debt.amount }}
+                      Te deben ({{single_debt.currency_code }}) {{ single_debt.amount }}
                     </span>
                     <span
                       v-else
                     >
-                      Debes ${{ single_debt.amount }}
+                      Debes ({{single_debt.currency_code }}) {{ single_debt.amount }}
                     </span>
                   </div>
                 </div>
                 <div 
-                  v-if="!single_debt.type" 
+                  v-if="supportedCurrencies.includes(single_debt.currency_code) && !single_debt.type" 
                   class="flex-column content-center bg-indigo-800 ml-auto"
                 >
                   <linkButton
@@ -122,17 +122,17 @@
                       <span
                         v-if="group_debt.type"
                       >
-                        Te deben ${{ group_debt.amount }}
+                        Te deben ({{group_debt.currency_code }}) {{ group_debt.amount }}
                       </span>
                       <span
                         v-else
                       >
-                        Debes ${{ group_debt.amount }}
+                        Debes ({{group_debt.currency_code }}) {{ group_debt.amount }}
                       </span>
                     </div>
                   </div>
                   <div 
-                    v-if="group_debt.is_payable && !group_debt.type" 
+                    v-if="supportedCurrencies.includes(group_debt.currency_code) && !group_debt.type" 
                     class="flex-column content-center bg-indigo-800 ml-auto"
                   >
                     <linkButton
@@ -178,6 +178,7 @@ export default {
     return {
       routeName: 'home',
       debtsColumns: ['', '', 'Nombre', 'Monto', ''],
+      supportedCurrencies: ['BTC', 'CLP'],
     };
   },
   created() {


### PR DESCRIPTION
1. En la lista de deudas del usuario, se cambió el "$" por el código de moneda. En ocasiones habían deudas en otras monedas y esto causaba confusión.
2. El botón pagar no se muestra si la deuda no está en una moneda soportada, es decir, no es CLP o BTC.

![image](https://user-images.githubusercontent.com/37151952/86424346-4ec4ae80-bcb0-11ea-8542-3157b57ab0fb.png)
