### PR TITLE
Fix splitwise currency

### DIFF
--- a/app/controllers/api/v1/splitwise/debts_controller.rb
+++ b/app/controllers/api/v1/splitwise/debts_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Splitwise::DebtsController < ApplicationController
   end
 
   def create
-    response = generate_splitwise_service.payoff_debt(params[:amount_clp], params[:currency_code], params[:group_id], params[:to_user_id])
+    response = generate_splitwise_service.payoff_debt(params[:amount], params[:currency_code], params[:group_id], params[:to_user_id])
     if response.code != '200'
       head(:unauthorized)
     end

--- a/app/controllers/api/v1/splitwise/debts_controller.rb
+++ b/app/controllers/api/v1/splitwise/debts_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Splitwise::DebtsController < ApplicationController
   end
 
   def create
-    response = generate_splitwise_service.payoff_debt(params[:amount_clp], params[:group_id], params[:to_user_id])
+    response = generate_splitwise_service.payoff_debt(params[:amount_clp], params[:currency_code], params[:group_id], params[:to_user_id])
     if response.code != '200'
       head(:unauthorized)
     end

--- a/app/services/splitwise_service.rb
+++ b/app/services/splitwise_service.rb
@@ -18,10 +18,11 @@ class SplitwiseService < PowerTypes::Service.new(:user)
 
   # POST methods from Splitwise API
 
-  def payoff_debt(amount, group_id, to_user_id)
+  def payoff_debt(amount, currency_code, group_id, to_user_id)
     create_expense_url = 'https://secure.splitwise.com/api/v3.0/create_expense'
     post_to_splitwise(create_expense_url, {
                         "cost": amount,
+                        "currency_code": currency_code,
                         "payment": true,
                         "group_id": group_id,
                         "description": 'Pago hecho a traves de BitSplit',


### PR DESCRIPTION
Agrego nuevo parámetro `currency_code` a controlador y servicio de splitwise
Cambio `amount_clp` a solo `amount` 