### PR TITLE
[web] Filter payments history

### DIFF
--- a/app/javascript/store/modules/paymentsHistory/index.js
+++ b/app/javascript/store/modules/paymentsHistory/index.js
@@ -25,7 +25,6 @@ const actions = {
             payment.attributes.receiver.email
         );
         commit(GET_PAYMENTS_SUCCESS, payments);
-        commit(GET_PAYMENTS_SUCCESS, res.data.data.transactions);
       })
       .catch(err => {
         commit(GET_PAYMENTS_FAIL);

--- a/app/javascript/store/modules/paymentsHistory/index.js
+++ b/app/javascript/store/modules/paymentsHistory/index.js
@@ -19,6 +19,12 @@ const actions = {
 
     return getPaymentsApi(payload)
       .then(res => {
+        const payments = res.data.data.transactions.filter(
+          payment =>
+            payment.attributes.sender.email !==
+            payment.attributes.receiver.email
+        );
+        commit(GET_PAYMENTS_SUCCESS, payments);
         commit(GET_PAYMENTS_SUCCESS, res.data.data.transactions);
       })
       .catch(err => {


### PR DESCRIPTION
Se hace un filtro de las transacciones para mostrar en el historial solo transferencias entre dos usuarios y no depósitos o abonos internos del usuario.
![image](https://user-images.githubusercontent.com/30701219/86551709-deb66280-bf13-11ea-9a6a-4e27b4b8d4cb.png)
