### PR TITLE
[web] fix: hot fixes

### DIFF
--- a/app/javascript/components/buda/BudaForm.vue
+++ b/app/javascript/components/buda/BudaForm.vue
@@ -90,7 +90,7 @@ export default {
             if (this.onBoardingScreen) {
               this.currentStepOk();
             } else {
-              this.$router.push('/home');
+              this.$router.go();
             }
           })
           .catch(err => {

--- a/app/javascript/components/buda/BudaLogoutForm.vue
+++ b/app/javascript/components/buda/BudaLogoutForm.vue
@@ -69,7 +69,7 @@ export default {
             if (this.onBoardingScreen) {
               this.changeBudaComp('BudaForm');
             } else {
-              this.$router.push('/home');
+              this.$router.go();
             }
           })
           .catch(err => {

--- a/app/javascript/router/SplitwiseIndex.vue
+++ b/app/javascript/router/SplitwiseIndex.vue
@@ -218,7 +218,9 @@ export default {
     };
   },
   created() {
-    this.getSplitwiseDebts();
+    if (this.splitwiseSignedIn){
+      this.getSplitwiseDebts();
+    }
   },
   components: {
     linkButton,

--- a/app/javascript/store/modules/user/actions.js
+++ b/app/javascript/store/modules/user/actions.js
@@ -327,43 +327,7 @@ export default {
           });
       });
   },
-  [budaSignOut]({ state, commit, dispatch }, payload) {
-    /* Update endpoint needed
-    const fetchPromise = budaSyncApi(payload);
-
-    return fetchPromise
-      .then(() => {
-        dispatch(
-          'alert/successAlert',
-          'Cuenta Buda desconectada correctamente',
-          { root: true }
-        );
-        const fetchPromiseUser = getCurrentUserApi();
-
-        return fetchPromiseUser.then(res => {
-          commitAndSetUser({
-            commit,
-            mutation: BUDA_SIGNOUT,
-            user: { ...state.currentUser, ...res.data.data.attributes },
-          });
-        });
-      })
-      .catch(err => {
-        if (err.response) {
-          dispatch(
-            'alert/errorAlert',
-            'Error desconectando cuenta. Revise la contraseña ingresada',
-            { root: true }
-          );
-          throw new Error(
-            'Error desconectando cuenta. Revise la contraseña ingresada'
-          );
-        } else {
-          dispatch('alert/errorAlert', 'Error desconocido', { root: true });
-          throw new Error('Error desconocido');
-        }
-      });
-      */
+  [budaSignOut]({ dispatch }, payload) {
     const fetchPromise = budaSyncApi(payload);
 
     return fetchPromise

--- a/app/javascript/store/modules/user/actions.js
+++ b/app/javascript/store/modules/user/actions.js
@@ -328,6 +328,7 @@ export default {
       });
   },
   [budaSignOut]({ state, commit, dispatch }, payload) {
+    /* Update endpoint needed
     const fetchPromise = budaSyncApi(payload);
 
     return fetchPromise
@@ -357,6 +358,19 @@ export default {
           throw new Error(
             'Error desconectando cuenta. Revise la contraseña ingresada'
           );
+        } else {
+          dispatch('alert/errorAlert', 'Error desconocido', { root: true });
+          throw new Error('Error desconocido');
+        }
+      });
+      */
+    const fetchPromise = budaSyncApi(payload);
+
+    return fetchPromise
+      .catch(err => {
+        if (err.response) {
+          return
+
         } else {
           dispatch('alert/errorAlert', 'Error desconocido', { root: true });
           throw new Error('Error desconocido');


### PR DESCRIPTION
1. Se corrigió la alerta "Error obteniendo deudas Splitwise".
2. Se arregló de forma parche el error que aparecía cuando se intentaban borrar las credenciales Buda.
3. Al registrar, actualizar o borrar credenciales buda ya no te redirige a home, si no al mismo perfil.